### PR TITLE
Get logger collection

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -56,12 +56,14 @@ class Factory
     public function createCollectionLogger($name, $config)
     {
         $loggerCollection = new Collection();
-        foreach ($config['loggers'] as $index => $loggerConfig) {
-            try {
-                $logger = $this->createLogger($name, $loggerConfig);
-            } catch (\DomainException $e) {
-                $message = sprintf('%s at index %d', $e->getMessage(), $index);
-                throw new \DomainException($message, null, $e);
+        foreach ($config['loggers'] as $index => $logger) {
+            if (!$logger instanceof LoggerInterface) {
+                try {
+                    $logger = $this->createLogger($name, $logger);
+                } catch (\DomainException $e) {
+                    $message = sprintf('%s at index %d', $e->getMessage(), $index);
+                    throw new \DomainException($message, null, $e);
+                }
             }
             $loggerCollection->add($logger);
         }

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -72,6 +72,23 @@ class Pool
 
     /**
      * @param string $name
+     * @return Collection
+     */
+    public function getLoggerCollection($name)
+    {
+        $logger = $this->getLogger($name);
+
+        if (!$logger instanceof Collection) {
+            $logger = $this->loggerFactory->createCollectionLogger($name, [
+                'loggers' => [$logger]
+            ]);
+        }
+
+        return $logger;
+    }
+
+    /**
+     * @param string $name
      * @return LoggerInterface
      */
     protected function createLogger($name)

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -37,6 +37,18 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\Phlib\Logger\Collection', $logger);
     }
 
+    public function testCreateCollectionLoggerExistingLogger()
+    {
+        $existingLogger = $this->getMock('\Psr\Log\LoggerInterface');
+
+        $factory = new Factory();
+        $logger  = $factory->createCollectionLogger('test', [
+            'loggers' => [$existingLogger]
+        ]);
+
+        $this->assertInstanceOf('\Phlib\Logger\Collection', $logger);
+    }
+
     public function testCreateLoggerStreamUnfiltered()
     {
         $fh = fopen('php://memory', 'a');

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -139,4 +139,39 @@ class PoolTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($logger, $pool->getLogger('test'));
     }
+
+    public function testGetLoggerCollection()
+    {
+        $streamConfig = [
+            'name' => 'stream',
+        ];
+
+        $config = [
+            'test' => $streamConfig
+        ];
+
+        $factory          = $this->getMock('\Phlib\Logger\Factory');
+        $streamLogger     = $this->getMockBuilder('\Phlib\Logger\Stream')->disableOriginalConstructor()->getMock();
+        $collectionLogger = $this->getMock('\Phlib\Logger\Collection');
+        $factory->expects($this->once())
+            ->method('createLogger')
+            ->with(
+                $this->equalTo('test'),
+                $this->equalTo($streamConfig)
+            )
+            ->will($this->returnValue($streamLogger));
+        $factory->expects($this->once())
+            ->method('createCollectionLogger')
+            ->with(
+                $this->equalTo('test'),
+                $this->equalTo([
+                    'loggers' => [$streamLogger]
+                ])
+            )
+            ->will($this->returnValue($collectionLogger));
+
+        $pool = new Pool($config, $factory);
+
+        $this->assertSame($collectionLogger, $pool->getLoggerCollection('test'));
+    }
 }


### PR DESCRIPTION
Add new method to Pool class to allow user to always get a collection logger.

Includes improvement to createCollectionLogger method on Factory class to allow for existing instances of \Psr\Log\LoggerInterface to be given in the loggers config.
