### PR TITLE
Logger config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ $loggerConfig = [
 Creation of logger pool
 
 ``` php
-$loggerPool = new \Phlib\Logger\Pool($loggerConfig, new \Phlib\Logger\Factory());
+$loggerPool = new \Phlib\Logger\Pool(
+    new \Phlib\Logger\Config($loggerConfig), 
+    new \Phlib\Logger\Factory()
+);
 
 ```
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Phlib\Logger;
+
+/**
+ * Class Config
+ * @package Phlib\Logger
+ */
+class Config
+{
+    /**
+     * @var array
+     */
+    protected $config;
+
+    /**
+     * @param array $config
+     */
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @param string $name
+     * @return array
+     */
+    public function getLoggerConfig($name)
+    {
+        $loggerConfig = $this->resolveAliases($name);
+
+        if (!isset($loggerConfig['name'])) {
+            $loggerConfig = [
+                'name'    => Factory::LOGGER_COLLECTION,
+                'loggers' => $loggerConfig
+            ];
+        }
+
+        return $loggerConfig;
+    }
+
+    /**
+     * @param string $name
+     * @return array
+     */
+    protected function resolveAliases($name)
+    {
+        $loggerConfig = $name;
+
+        do {
+            $loggerConfig = isset($this->config[$loggerConfig]) ? $this->config[$loggerConfig] : [];
+        } while (is_string($loggerConfig));
+
+        if (!is_array($loggerConfig)) {
+            $loggerConfig = [];
+        }
+
+        return $loggerConfig;
+    }
+
+    /**
+     * @param string $name
+     * @return array
+     */
+    public function __get($name)
+    {
+        return $this->getLoggerConfig($name);
+    }
+
+}

--- a/src/Config.php
+++ b/src/Config.php
@@ -6,7 +6,7 @@ namespace Phlib\Logger;
  * Class Config
  * @package Phlib\Logger
  */
-class Config
+class Config implements ConfigInterface
 {
     /**
      * @var array

--- a/src/Config.php
+++ b/src/Config.php
@@ -58,13 +58,4 @@ class Config
         return $loggerConfig;
     }
 
-    /**
-     * @param string $name
-     * @return array
-     */
-    public function __get($name)
-    {
-        return $this->getLoggerConfig($name);
-    }
-
 }

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Phlib\Logger;
+
+/**
+ * Interface ConfigInterface
+ * @package Phlib\Logger
+ */
+interface ConfigInterface
+{
+
+    /**
+     * @param string $name
+     * @return array
+     */
+    public function getLoggerConfig($name);
+
+}

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -12,7 +12,7 @@ class Pool
 {
 
     /**
-     * @var array
+     * @var Config
      */
     protected $config;
 
@@ -32,10 +32,10 @@ class Pool
     protected $loggerFactory;
 
     /**
-     * @param array $config
+     * @param Config $config
      * @param Factory $loggerFactory
      */
-    public function __construct(array $config, Factory $loggerFactory)
+    public function __construct(Config $config, Factory $loggerFactory)
     {
         $this->config        = $config;
         $this->loggerFactory = $loggerFactory;
@@ -93,21 +93,7 @@ class Pool
      */
     protected function createLogger($name)
     {
-        $loggerConfig = $name;
-        do {
-            $loggerConfig = isset($this->config[$loggerConfig]) ? $this->config[$loggerConfig] : [];
-        } while (is_string($loggerConfig));
-
-        if (!is_array($loggerConfig)) {
-            $loggerConfig = [];
-        }
-
-        if (!isset($loggerConfig['name'])) {
-            $loggerConfig = [
-                'name'    => Factory::LOGGER_COLLECTION,
-                'loggers' => $loggerConfig
-            ];
-        }
+        $loggerConfig = $this->config->getLoggerConfig($name);
 
         return $this->loggerFactory->createLogger($this->prefix . $name, $loggerConfig);
     }

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -95,7 +95,7 @@ class Pool
     {
         $loggerConfig = $this->config->getLoggerConfig($name);
 
-        return $this->loggerFactory->createLogger($this->prefix . $name, $loggerConfig);
+        return $this->loggerFactory->createLogger($this->getPrefix() . $name, $loggerConfig);
     }
 
     /**

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -12,7 +12,7 @@ class Pool
 {
 
     /**
-     * @var Config
+     * @var ConfigInterface
      */
     protected $config;
 
@@ -32,10 +32,10 @@ class Pool
     protected $loggerFactory;
 
     /**
-     * @param Config $config
+     * @param ConfigInterface $config
      * @param Factory $loggerFactory
      */
-    public function __construct(Config $config, Factory $loggerFactory)
+    public function __construct(ConfigInterface $config, Factory $loggerFactory)
     {
         $this->config        = $config;
         $this->loggerFactory = $loggerFactory;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -80,4 +80,20 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($streamConfig, $config->getLoggerConfig('test'));
     }
+
+    public function testInvalidLoggerConfigType()
+    {
+        $configArray = [
+            'test' => false
+        ];
+
+        $config = new Config($configArray);
+
+        $expected = [
+            'name'    => Factory::LOGGER_COLLECTION,
+            'loggers' => []
+        ];
+
+        $this->assertEquals($expected, $config->getLoggerConfig('test'));
+    }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Phlib\Logger\Test;
+
+use Phlib\Logger\Config;
+use Phlib\Logger\Factory;
+use Psr\Log\LogLevel;
+
+class ConfigTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testEmptyConfig()
+    {
+        $configArray = [];
+        $config = new Config($configArray);
+
+        $expected = [
+            'name'    => Factory::LOGGER_COLLECTION,
+            'loggers' => []
+        ];
+
+        $this->assertEquals($expected, $config->test);
+    }
+
+    public function testStream()
+    {
+        $streamConfig = [
+            'name' => Factory::LOGGER_STREAM,
+            'path' => '(filename)'
+        ];
+
+        $configArray = [
+            'test' => $streamConfig
+        ];
+
+        $config = new Config($configArray);
+
+        $this->assertEquals($streamConfig, $config->test);
+    }
+
+    public function testCollectionCoerce()
+    {
+        $gelfConfig = [
+            'name' => Factory::LOGGER_GELF,
+        ];
+
+        $configArray = [
+            'test' => [
+                $gelfConfig
+            ]
+        ];
+
+        $config = new Config($configArray);
+
+        $expected = [
+            'name'    => Factory::LOGGER_COLLECTION,
+            'loggers' => [
+                $gelfConfig
+            ]
+        ];
+
+        $this->assertEquals($expected, $config->test);
+    }
+
+    public function testAlias()
+    {
+        $streamConfig = [
+            'name'  => Factory::LOGGER_STREAM,
+            'level' => LogLevel::CRITICAL,
+            'path'  => '(filename)'
+        ];
+
+        $configArray = [
+            'test'  => 'test1',
+            'test1' => 'test2',
+            'test2' => $streamConfig
+        ];
+
+        $config = new Config($configArray);
+
+        $this->assertEquals($streamConfig, $config->test);
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -19,7 +19,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             'loggers' => []
         ];
 
-        $this->assertEquals($expected, $config->test);
+        $this->assertEquals($expected, $config->getLoggerConfig('test'));
     }
 
     public function testStream()
@@ -35,7 +35,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
         $config = new Config($configArray);
 
-        $this->assertEquals($streamConfig, $config->test);
+        $this->assertEquals($streamConfig, $config->getLoggerConfig('test'));
     }
 
     public function testCollectionCoerce()
@@ -59,7 +59,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             ]
         ];
 
-        $this->assertEquals($expected, $config->test);
+        $this->assertEquals($expected, $config->getLoggerConfig('test'));
     }
 
     public function testAlias()
@@ -78,6 +78,6 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
         $config = new Config($configArray);
 
-        $this->assertEquals($streamConfig, $config->test);
+        $this->assertEquals($streamConfig, $config->getLoggerConfig('test'));
     }
 }

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -2,153 +2,109 @@
 
 namespace Phlib\Logger\Test;
 
+use Phlib\Logger\Factory;
 use Phlib\Logger\Pool;
 use Psr\Log\LogLevel;
 
 class PoolTest extends \PHPUnit_Framework_TestCase
 {
 
-    public function testEmptyLogger()
+    public function testGetLogger()
     {
+        $loggerConfig = [
+            'name'    => Factory::LOGGER_COLLECTION,
+            'loggers' => []
+        ];
+
+        $config  = $this->getMock('\Phlib\Logger\Config', [], [[]]);
+        $config->expects($this->once())
+            ->method('getLoggerConfig')
+            ->with($this->equalTo('test'))
+            ->will($this->returnValue($loggerConfig));
+
         $factory = $this->getMock('\Phlib\Logger\Factory');
         $logger  = $this->getMock('\Phlib\Logger\Collection');
         $factory->expects($this->once())
             ->method('createLogger')
-            ->with(
-                $this->equalTo('test'),
-                $this->equalTo([
-                    'name'    => 'collection',
-                    'loggers' => []
-                ])
-            )
+            ->with($this->equalTo('test'), $this->equalTo($loggerConfig))
             ->will($this->returnValue($logger));
 
-        $pool = new Pool([], $factory);
+        $pool = new Pool($config, $factory);
 
         $this->assertSame($logger, $pool->test);
     }
 
-    public function testStream()
+    public function testGetLoggerAgain()
     {
-        $streamConfig = [
-            'name' => 'stream',
+        $loggerConfig = [
+            'name' => Factory::LOGGER_STREAM,
+            'path' => '(filename)'
         ];
 
-        $config = [
-            'test' => $streamConfig
-        ];
+        $config  = $this->getMock('\Phlib\Logger\Config', [], [[]]);
+        $config->expects($this->once())
+            ->method('getLoggerConfig')
+            ->with($this->equalTo('test'))
+            ->will($this->returnValue($loggerConfig));
 
         $factory = $this->getMock('\Phlib\Logger\Factory');
         $logger  = $this->getMockBuilder('\Phlib\Logger\Stream')->disableOriginalConstructor()->getMock();
         $factory->expects($this->once())
             ->method('createLogger')
-            ->with(
-                $this->equalTo('test'),
-                $this->equalTo($streamConfig)
-            )
+            ->with($this->equalTo('test'), $this->equalTo($loggerConfig))
             ->will($this->returnValue($logger));
+
         $pool = new Pool($config, $factory);
 
-        $this->assertSame($logger, $pool->test);
-    }
+        $actualLogger = $pool->test;
 
-    public function testCollectionStream()
-    {
-        $streamConfig = [
-            'name' => 'stream',
-        ];
+        $this->assertSame($logger, $actualLogger);
 
-        $config = [
-            'test' => [
-                $streamConfig
-            ]
-        ];
-
-        $factory = $this->getMock('\Phlib\Logger\Factory');
-        $logger  = $this->getMock('\Phlib\Logger\Collection');
-        $factory->expects($this->once())
-            ->method('createLogger')
-            ->with(
-                $this->equalTo('test'),
-                $this->equalTo([
-                    'name'    => 'collection',
-                    'loggers' => [$streamConfig]
-                ])
-            )
-            ->will($this->returnValue($logger));
-        $pool = new Pool($config, $factory);
-
-        $this->assertSame($logger, $pool->test);
+        $this->assertSame($actualLogger, $pool->test);
     }
 
     public function testPrefix()
     {
-        $config = [
-            'test' => [
-                [
-                    'name'  => 'stream',
-                    'level' => LogLevel::CRITICAL,
-                    'path'  => '(filename)'
-                ]
-            ]
+        $prefix = 'logger-prefix-';
+
+        $loggerConfig = [
+            'name'  => Factory::LOGGER_GELF,
+            'level' => LogLevel::CRITICAL,
+            'host'  => '(hostname)'
         ];
 
+        $config  = $this->getMock('\Phlib\Logger\Config', [], [[]]);
+        $config->expects($this->once())
+            ->method('getLoggerConfig')
+            ->with($this->equalTo('test'))
+            ->will($this->returnValue($loggerConfig));
+
         $factory = $this->getMock('\Phlib\Logger\Factory');
-        $logger  = $this->getMock('\Phlib\Logger\Collection');
+        $logger  = $this->getMock('\Phlib\Logger\Gelf');
         $factory->expects($this->once())
             ->method('createLogger')
-            ->with($this->equalTo('logger-prefix-test'))
+            ->with($this->equalTo($prefix . 'test'))
             ->will($this->returnValue($logger));
 
         $pool = new Pool($config, $factory);
-        $pool->setPrefix('logger-prefix-');
+        $pool->setPrefix($prefix);
 
         $this->assertSame($logger, $pool->test);
     }
 
-    public function testAlias()
-    {
-        $loggers = [
-            [
-                'name'  => 'stream',
-                'level' => LogLevel::CRITICAL,
-                'path'  => '(filename)'
-            ]
-        ];
-        $config = [
-            'test'  => 'test1',
-            'test1' => 'test2',
-            'test2' => $loggers
-        ];
-
-
-        $factory = $this->getMock('\Phlib\Logger\Factory');
-        $logger  = $this->getMock('\Phlib\Logger\Collection');
-        $factory->expects($this->once())
-            ->method('createLogger')
-            ->with(
-                $this->equalTo('test'),
-                $this->equalTo([
-                    'name'    => 'collection',
-                    'loggers' => $loggers
-                ])
-            )
-            ->will($this->returnValue($logger));
-
-        $pool = new Pool($config, $factory);
-
-        $this->assertSame($logger, $pool->getLogger('test'));
-    }
-
     public function testGetLoggerCollection()
     {
-        $streamConfig = [
-            'name' => 'stream',
+        $loggerConfig = [
+            'name'  => Factory::LOGGER_STREAM,
+            'level' => LogLevel::WARNING,
+            'path'  => '(filename)'
         ];
 
-        $config = [
-            'test' => $streamConfig
-        ];
+        $config  = $this->getMock('\Phlib\Logger\Config', [], [[]]);
+        $config->expects($this->once())
+            ->method('getLoggerConfig')
+            ->with($this->equalTo('test'))
+            ->will($this->returnValue($loggerConfig));
 
         $factory          = $this->getMock('\Phlib\Logger\Factory');
         $streamLogger     = $this->getMockBuilder('\Phlib\Logger\Stream')->disableOriginalConstructor()->getMock();
@@ -157,7 +113,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
             ->method('createLogger')
             ->with(
                 $this->equalTo('test'),
-                $this->equalTo($streamConfig)
+                $this->equalTo($loggerConfig)
             )
             ->will($this->returnValue($streamLogger));
         $factory->expects($this->once())


### PR DESCRIPTION
Separate the logic for interpreting the pool's config into a new class (with a reusable interface).

Now means that the pool is mostly only responsible for storing the instances of loggers and providing a central point of access to this library
