### PR TITLE
Logger type

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ $loggerConfig = [
     'default' => [ // logger config identifier, used as facility/name in log messages
         // multiple logger entries becomes a collection logger
         [
-            // name of the logger type (stream, gelf...)
-            'name'  => 'stream',
+            // logger type (stream, gelf...)
+            'type'  => 'stream',
             // the level of log messages to include (optional)
             'level' => \Psr\Log\LogLevel::ERROR, 
              // logger specific parameters
             'path'  => '/var/log/my_app.log'
         ],
         [
-            'name'  => 'gelf',                
+            'type'  => 'gelf',                
             'level' => \Psr\Log\LogLevel::INFO,
              // logger specific parameters
             'host'  => '127.0.0.1',
@@ -40,7 +40,7 @@ $loggerConfig = [
     ],
     'application' => 'default', // alias to another logger config
     'api' => [
-        'name' => 'gelf',
+        'type' => 'gelf',
         'host' => '127.0.0.1',
         'port' => 12201 
     ]

--- a/src/Config.php
+++ b/src/Config.php
@@ -29,10 +29,10 @@ class Config implements ConfigInterface
     {
         $loggerConfig = $this->resolveAliases($name);
 
-        if (!isset($loggerConfig['name'])) {
+        if (!isset($loggerConfig[Factory::LOGGER_TYPE])) {
             $loggerConfig = [
-                'name'    => Factory::LOGGER_COLLECTION,
-                'loggers' => $loggerConfig
+                Factory::LOGGER_TYPE => Factory::LOGGER_TYPE_COLLECTION,
+                'loggers'            => $loggerConfig
             ];
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -29,10 +29,10 @@ class Config implements ConfigInterface
     {
         $loggerConfig = $this->resolveAliases($name);
 
-        if (!isset($loggerConfig[Factory::LOGGER_TYPE])) {
+        if (!isset($loggerConfig['type'])) {
             $loggerConfig = [
-                Factory::LOGGER_TYPE => Factory::LOGGER_TYPE_COLLECTION,
-                'loggers'            => $loggerConfig
+                'type'    => Factory::LOGGER_TYPE_COLLECTION,
+                'loggers' => $loggerConfig
             ];
         }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -11,9 +11,11 @@ use Psr\Log\LogLevel;
  */
 class Factory
 {
-    const LOGGER_COLLECTION = 'collection';
-    const LOGGER_STREAM     = 'stream';
-    const LOGGER_GELF       = 'gelf';
+    const LOGGER_TYPE = 'type';
+
+    const LOGGER_TYPE_COLLECTION = 'collection';
+    const LOGGER_TYPE_STREAM     = 'stream';
+    const LOGGER_TYPE_GELF       = 'gelf';
 
     /**
      * @param string $name
@@ -23,22 +25,22 @@ class Factory
      */
     public function createLogger($name, array $config)
     {
-        if (!isset($config['name'])) {
-            throw new \DomainException('Logger config missing name');
+        if (!isset($config[self::LOGGER_TYPE])) {
+            throw new \DomainException('Logger config missing logger type');
         }
-        $type = $config['name'];
+        $type = $config[self::LOGGER_TYPE];
         switch (strtolower($type)) {
-            case self::LOGGER_COLLECTION:
+            case self::LOGGER_TYPE_COLLECTION:
                 $logger = $this->createCollectionLogger($name, $config);
                 break;
-            case self::LOGGER_STREAM:
+            case self::LOGGER_TYPE_STREAM:
                 $logger = $this->createStreamLogger($name, $config);
                 break;
-            case self::LOGGER_GELF:
+            case self::LOGGER_TYPE_GELF:
                 $logger = $this->createGelfLogger($name, $config);
                 break;
             default:
-                throw new \DomainException(sprintf('Cannot find a logger named "%s"', $type));
+                throw new \DomainException(sprintf('Cannot find a logger type named "%s"', $type));
         }
         $logLevel = isset($config['level']) ? $config['level'] : LogLevel::DEBUG;
         if ($logLevel !== LogLevel::DEBUG) {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -11,8 +11,6 @@ use Psr\Log\LogLevel;
  */
 class Factory
 {
-    const LOGGER_TYPE = 'type';
-
     const LOGGER_TYPE_COLLECTION = 'collection';
     const LOGGER_TYPE_STREAM     = 'stream';
     const LOGGER_TYPE_GELF       = 'gelf';
@@ -25,10 +23,10 @@ class Factory
      */
     public function createLogger($name, array $config)
     {
-        if (!isset($config[self::LOGGER_TYPE])) {
+        if (!isset($config['type'])) {
             throw new \DomainException('Logger config missing logger type');
         }
-        $type = $config[self::LOGGER_TYPE];
+        $type = $config['type'];
         switch (strtolower($type)) {
             case self::LOGGER_TYPE_COLLECTION:
                 $logger = $this->createCollectionLogger($name, $config);

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -15,7 +15,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $config = new Config($configArray);
 
         $expected = [
-            'name'    => Factory::LOGGER_COLLECTION,
+            'type'    => Factory::LOGGER_TYPE_COLLECTION,
             'loggers' => []
         ];
 
@@ -25,7 +25,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testStream()
     {
         $streamConfig = [
-            'name' => Factory::LOGGER_STREAM,
+            'type' => Factory::LOGGER_TYPE_STREAM,
             'path' => '(filename)'
         ];
 
@@ -41,7 +41,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testCollectionCoerce()
     {
         $gelfConfig = [
-            'name' => Factory::LOGGER_GELF,
+            'type' => Factory::LOGGER_TYPE_GELF,
         ];
 
         $configArray = [
@@ -53,7 +53,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $config = new Config($configArray);
 
         $expected = [
-            'name'    => Factory::LOGGER_COLLECTION,
+            'type'    => Factory::LOGGER_TYPE_COLLECTION,
             'loggers' => [
                 $gelfConfig
             ]
@@ -65,7 +65,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testAlias()
     {
         $streamConfig = [
-            'name'  => Factory::LOGGER_STREAM,
+            'type'  => Factory::LOGGER_TYPE_STREAM,
             'level' => LogLevel::CRITICAL,
             'path'  => '(filename)'
         ];
@@ -90,7 +90,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $config = new Config($configArray);
 
         $expected = [
-            'name'    => Factory::LOGGER_COLLECTION,
+            'type'    => Factory::LOGGER_TYPE_COLLECTION,
             'loggers' => []
         ];
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -52,7 +52,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     public function testCreateCollectionLoggerWithConfig()
     {
         $gelfConfig = [
-            'name' => Factory::LOGGER_GELF,
+            'type' => Factory::LOGGER_TYPE_GELF,
             'host' => '127.0.0.1'
         ];
 
@@ -71,7 +71,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     public function testCreateCollectionLoggerWithInvalidConfig()
     {
         $invalidConfig = [
-            'name' => '(invalid)',
+            'type' => '(invalid)',
         ];
 
         $factory = new Factory();
@@ -86,7 +86,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory = new Factory();
         $logger  = $factory->createLogger('test', [
-            'name' => 'stream',
+            'type' => 'stream',
             'path' => $fh
         ]);
 
@@ -97,7 +97,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     {
         $factory = new Factory();
         $logger  = $factory->createLogger('test', [
-            'name' => 'gelf',
+            'type' => 'gelf',
             'host' => '127.0.0.1'
         ]);
 
@@ -108,7 +108,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     {
         $factory = new Factory();
         $logger  = $factory->createLogger('test', [
-            'name'    => 'collection',
+            'type'    => 'collection',
             'loggers' => []
         ]);
 
@@ -121,7 +121,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory = new Factory();
         $logger  = $factory->createLogger('test', [
-            'name'  => 'stream',
+            'type'   => 'stream',
             'level' => LogLevel::ERROR,
             'path'  => $fh
         ]);
@@ -131,9 +131,9 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \DomainException
-     * @expectedExceptionMessage Logger config missing name
+     * @expectedExceptionMessage Logger config missing logger type
      */
-    public function testCreateLoggerMissingLoggerName()
+    public function testCreateLoggerMissingLoggerType()
     {
         $factory = new Factory();
         $factory->createLogger('test', [ 'path' => 'filename' ]);
@@ -141,11 +141,11 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \DomainException
-     * @expectedExceptionMessage Cannot find a logger named
+     * @expectedExceptionMessage Cannot find a logger type named
      */
     public function testCreateLoggerInvalidLogger()
     {
         $factory = new Factory();
-        $factory->createLogger('test', [ 'name' => 'unknown', 'path' => '(filename)' ]);
+        $factory->createLogger('test', [ 'type' => 'unknown', 'path' => '(filename)' ]);
     }
 }

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -12,7 +12,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
     public function testGetLogger()
     {
         $loggerConfig = [
-            'name'    => Factory::LOGGER_COLLECTION,
+            'type'    => Factory::LOGGER_TYPE_COLLECTION,
             'loggers' => []
         ];
 
@@ -37,7 +37,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
     public function testGetLoggerAgain()
     {
         $loggerConfig = [
-            'name' => Factory::LOGGER_STREAM,
+            'type' => Factory::LOGGER_TYPE_STREAM,
             'path' => '(filename)'
         ];
 
@@ -68,7 +68,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $prefix = 'logger-prefix-';
 
         $loggerConfig = [
-            'name'  => Factory::LOGGER_GELF,
+            'type'  => Factory::LOGGER_TYPE_GELF,
             'level' => LogLevel::CRITICAL,
             'host'  => '(hostname)'
         ];
@@ -95,7 +95,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
     public function testGetLoggerCollection()
     {
         $loggerConfig = [
-            'name'  => Factory::LOGGER_STREAM,
+            'type'  => Factory::LOGGER_TYPE_STREAM,
             'level' => LogLevel::WARNING,
             'path'  => '(filename)'
         ];


### PR DESCRIPTION
Change the 'name' key in the logger config to 'type', to avoid confusion with the logger's name which is used for the stream name and Gelf facility, and to identify loggers in the logger pool.
