### PR TITLE
Add CLI logger with colours

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,9 @@
         }
     ],
     "require": {
+        "psr/log": "^1.0",
         "graylog2/gelf-php": "^1.3",
-        "psr/log": "^1.0"
+        "symfony/console": "^3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,10 @@
         }
     ],
     "require": {
+        "php": "^5.4",
         "psr/log": "^1.0",
         "graylog2/gelf-php": "^1.3",
-        "symfony/console": "^3"
+        "symfony/console": "^2.5.12|^3"
     },
     "autoload": {
         "psr-4": {

--- a/src/CliColor.php
+++ b/src/CliColor.php
@@ -17,12 +17,12 @@ class CliColor extends Stream
     /**
      * @var string
      */
-    private $originalMessageFormat;
+    private $currentLevel;
 
     /**
      * @var OutputFormatter
      */
-    protected $formatter;
+    private $formatter;
 
     /**
      * @see Stream::__construct()
@@ -32,8 +32,6 @@ class CliColor extends Stream
     public function __construct($name, $stream = STDERR)
     {
         parent::__construct($name, $stream);
-
-        $this->originalMessageFormat = $this->messageFormat;
 
         $this->formatter = new OutputFormatter(true, [
             'debug'     => new OutputFormatterStyle(),
@@ -58,22 +56,20 @@ class CliColor extends Stream
      */
     public function log($level, $message, array $context = array())
     {
-        $format = "<{$level}>{$this->originalMessageFormat}</{$level}>";
-        $this->messageFormat = $this->formatter->format($format);
+        $this->currentLevel = $level;
 
         parent::log($level, $message, $context);
     }
 
     /**
-     * @see Stream::setMessageFormat()
-     * @param string $format
-     * @return $this
+     * @see Stream::getMessageFormat()
+     * @return string
      */
-    public function setMessageFormat($format)
+    protected function getMessageFormat()
     {
-        $this->originalMessageFormat = $format;
+        $format = parent::getMessageFormat();
+        $format = "<{$this->currentLevel}>{$format}</{$this->currentLevel}>";
 
-        return parent::setMessageFormat($format);
+        return $this->formatter->format($format);
     }
-
 }

--- a/src/CliColor.php
+++ b/src/CliColor.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Phlib\Logger;
+
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+
+/**
+ * Class CliColor
+ *
+ * Write to CLI with colour!
+ *
+ * @package Phlib\Logger
+ */
+class CliColor extends Stream
+{
+    /**
+     * @var string
+     */
+    private $originalMessageFormat;
+
+    /**
+     * @var OutputFormatter
+     */
+    protected $formatter;
+
+    /**
+     * @see Stream::__construct()
+     * @param string $name
+     * @param resource|string $stream Optional. Default to Standard Error
+     */
+    public function __construct($name, $stream = STDERR)
+    {
+        parent::__construct($name, $stream);
+
+        $this->originalMessageFormat = $this->messageFormat;
+
+        $this->formatter = new OutputFormatter(true, [
+            'debug'     => new OutputFormatterStyle(),
+            'info'      => new OutputFormatterStyle('blue'),
+            'notice'    => new OutputFormatterStyle('green'),
+            'warning'   => new OutputFormatterStyle('yellow'),
+            'error'     => new OutputFormatterStyle('red'),
+            'critical'  => new OutputFormatterStyle('red', 'yellow'),
+            'alert'     => new OutputFormatterStyle('white', 'red', ['bold']),
+            'emergency' => new OutputFormatterStyle('white', 'red', ['bold', 'underscore'])
+        ]);
+    }
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @see Stream::log()
+     * @param mixed $level
+     * @param string $message
+     * @param array $context
+     * @return void
+     */
+    public function log($level, $message, array $context = array())
+    {
+        $format = "<{$level}>{$this->originalMessageFormat}</{$level}>";
+        $this->messageFormat = $this->formatter->format($format);
+
+        parent::log($level, $message, $context);
+    }
+
+    /**
+     * @see Stream::setMessageFormat()
+     * @param string $format
+     * @return $this
+     */
+    public function setMessageFormat($format)
+    {
+        $this->originalMessageFormat = $format;
+
+        return parent::setMessageFormat($format);
+    }
+
+}

--- a/src/CliColor.php
+++ b/src/CliColor.php
@@ -15,11 +15,6 @@ use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 class CliColor extends Stream
 {
     /**
-     * @var string
-     */
-    private $currentLevel;
-
-    /**
      * @var OutputFormatter
      */
     private $formatter;
@@ -46,30 +41,16 @@ class CliColor extends Stream
     }
 
     /**
-     * Logs with an arbitrary level.
-     *
-     * @see Stream::log()
-     * @param mixed $level
-     * @param string $message
-     * @param array $context
-     * @return void
-     */
-    public function log($level, $message, array $context = array())
-    {
-        $this->currentLevel = $level;
-
-        parent::log($level, $message, $context);
-    }
-
-    /**
      * @see Stream::getMessageFormat()
+     * @param mixed $level
+     * @param array $context
      * @return string
      */
-    protected function getMessageFormat()
+    protected function getMessageFormat($level, array $context = array())
     {
-        $format = parent::getMessageFormat();
-        $format = "<{$this->currentLevel}>{$format}</{$this->currentLevel}>";
+        $parentFormat = parent::getMessageFormat($level, $context);
+        $consoleFormat = "<{$level}>{$parentFormat}</{$level}>";
 
-        return $this->formatter->format($format);
+        return $this->formatter->format($consoleFormat);
     }
 }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -89,7 +89,7 @@ class Stream extends AbstractLogger
 
         $message = $this->interpolate($this->getMessageFormat(), $meta);
 
-        fwrite($this->stream, $message . "\n");
+        fwrite($this->stream, $message . PHP_EOL);
     }
 
     /**

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -14,7 +14,7 @@ class Stream extends AbstractLogger
     /**
      * @var string
      */
-    protected $messageFormat = "[{datetime}] {name}.{level}: {message} {context}\n";
+    protected $messageFormat = '[{datetime}] {name}.{level}: {message} {context}';
 
     /**
      * @var string
@@ -47,6 +47,18 @@ class Stream extends AbstractLogger
     }
 
     /**
+     * Get current message format
+     *
+     * This method can be overridden by extending classes to modify the behaviour
+     *
+     * @return string
+     */
+    protected function getMessageFormat()
+    {
+        return $this->messageFormat;
+    }
+
+    /**
      * @param string $format
      * @return $this
      */
@@ -63,7 +75,7 @@ class Stream extends AbstractLogger
      * @param mixed $level
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
     public function log($level, $message, array $context = array())
     {
@@ -75,9 +87,9 @@ class Stream extends AbstractLogger
             'context'  => $this->formatContext($context)
         ];
 
-        $message = $this->interpolate($this->messageFormat, $meta);
+        $message = $this->interpolate($this->getMessageFormat(), $meta);
 
-        fwrite($this->stream, $message);
+        fwrite($this->stream, $message . "\n");
     }
 
     /**

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -51,9 +51,11 @@ class Stream extends AbstractLogger
      *
      * This method can be overridden by extending classes to modify the behaviour
      *
+     * @param mixed $level
+     * @param array $context
      * @return string
      */
-    protected function getMessageFormat()
+    protected function getMessageFormat($level, array $context = array())
     {
         return $this->messageFormat;
     }
@@ -87,7 +89,7 @@ class Stream extends AbstractLogger
             'context'  => $this->formatContext($context)
         ];
 
-        $message = $this->interpolate($this->getMessageFormat(), $meta);
+        $message = $this->interpolate($this->getMessageFormat($level, $context), $meta);
 
         fwrite($this->stream, $message . PHP_EOL);
     }

--- a/tests/CliColorTest.php
+++ b/tests/CliColorTest.php
@@ -32,7 +32,7 @@ class CliColorTest extends \PHPUnit_Framework_TestCase
         $logMessage = fread($resource, 1024);
         $this->assertStringStartsWith("\033[34m", $logMessage);
         $this->assertContains($message, $logMessage);
-        $this->assertStringEndsWith("\033[39m", $logMessage);
+        $this->assertStringEndsWith("\033[39m\n", $logMessage);
     }
 
     public function testLogNotice()
@@ -47,7 +47,7 @@ class CliColorTest extends \PHPUnit_Framework_TestCase
         $logMessage = fread($resource, 1024);
         $this->assertStringStartsWith("\033[32m", $logMessage);
         $this->assertContains($message, $logMessage);
-        $this->assertStringEndsWith("\033[39m", $logMessage);
+        $this->assertStringEndsWith("\033[39m\n", $logMessage);
     }
 
     public function testLogWarning()
@@ -62,7 +62,7 @@ class CliColorTest extends \PHPUnit_Framework_TestCase
         $logMessage = fread($resource, 1024);
         $this->assertStringStartsWith("\033[33m", $logMessage);
         $this->assertContains($message, $logMessage);
-        $this->assertStringEndsWith("\033[39m", $logMessage);
+        $this->assertStringEndsWith("\033[39m\n", $logMessage);
     }
 
     public function testLogError()
@@ -77,7 +77,7 @@ class CliColorTest extends \PHPUnit_Framework_TestCase
         $logMessage = fread($resource, 1024);
         $this->assertStringStartsWith("\033[31m", $logMessage);
         $this->assertContains($message, $logMessage);
-        $this->assertStringEndsWith("\033[39m", $logMessage);
+        $this->assertStringEndsWith("\033[39m\n", $logMessage);
     }
 
     public function testLogCritical()
@@ -92,7 +92,7 @@ class CliColorTest extends \PHPUnit_Framework_TestCase
         $logMessage = fread($resource, 1024);
         $this->assertStringStartsWith("\033[31;43m", $logMessage);
         $this->assertContains($message, $logMessage);
-        $this->assertStringEndsWith("\033[39;49m", $logMessage);
+        $this->assertStringEndsWith("\033[39;49m\n", $logMessage);
     }
 
     public function testLogAlert()
@@ -107,7 +107,7 @@ class CliColorTest extends \PHPUnit_Framework_TestCase
         $logMessage = fread($resource, 1024);
         $this->assertStringStartsWith("\033[37;41;1m", $logMessage);
         $this->assertContains($message, $logMessage);
-        $this->assertStringEndsWith("\033[39;49;22m", $logMessage);
+        $this->assertStringEndsWith("\033[39;49;22m\n", $logMessage);
     }
 
     public function testLogEmergency()
@@ -122,6 +122,6 @@ class CliColorTest extends \PHPUnit_Framework_TestCase
         $logMessage = fread($resource, 1024);
         $this->assertStringStartsWith("\033[37;41;1;4m", $logMessage);
         $this->assertContains($message, $logMessage);
-        $this->assertStringEndsWith("\033[39;49;22;24m", $logMessage);
+        $this->assertStringEndsWith("\033[39;49;22;24m\n", $logMessage);
     }
 }

--- a/tests/CliColorTest.php
+++ b/tests/CliColorTest.php
@@ -1,0 +1,127 @@
+<?php
+namespace Phlib\Logger\Test;
+
+use Phlib\Logger\CliColor;
+use Psr\Log\LogLevel;
+
+class CliColorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testLogDebug()
+    {
+        $resource = fopen('php://memory', 'a');
+        $logger = new CliColor('name', $resource);
+
+        $message = 'Test Log Message';
+        $logger->log(LogLevel::DEBUG, $message);
+
+        rewind($resource);
+        $logMessage = fread($resource, 1024);
+        $this->assertNotContains("\033[", $logMessage);
+        $this->assertContains($message, $logMessage);
+    }
+
+    public function testLogInfo()
+    {
+        $resource = fopen('php://memory', 'a');
+        $logger = new CliColor('name', $resource);
+
+        $message = 'Test Log Message';
+        $logger->log(LogLevel::INFO, $message);
+
+        rewind($resource);
+        $logMessage = fread($resource, 1024);
+        $this->assertStringStartsWith("\033[34m", $logMessage);
+        $this->assertContains($message, $logMessage);
+        $this->assertStringEndsWith("\033[39m", $logMessage);
+    }
+
+    public function testLogNotice()
+    {
+        $resource = fopen('php://memory', 'a');
+        $logger = new CliColor('name', $resource);
+
+        $message = 'Test Log Message';
+        $logger->log(LogLevel::NOTICE, $message);
+
+        rewind($resource);
+        $logMessage = fread($resource, 1024);
+        $this->assertStringStartsWith("\033[32m", $logMessage);
+        $this->assertContains($message, $logMessage);
+        $this->assertStringEndsWith("\033[39m", $logMessage);
+    }
+
+    public function testLogWarning()
+    {
+        $resource = fopen('php://memory', 'a');
+        $logger = new CliColor('name', $resource);
+
+        $message = 'Test Log Message';
+        $logger->log(LogLevel::WARNING, $message);
+
+        rewind($resource);
+        $logMessage = fread($resource, 1024);
+        $this->assertStringStartsWith("\033[33m", $logMessage);
+        $this->assertContains($message, $logMessage);
+        $this->assertStringEndsWith("\033[39m", $logMessage);
+    }
+
+    public function testLogError()
+    {
+        $resource = fopen('php://memory', 'a');
+        $logger = new CliColor('name', $resource);
+
+        $message = 'Test Log Message';
+        $logger->log(LogLevel::ERROR, $message);
+
+        rewind($resource);
+        $logMessage = fread($resource, 1024);
+        $this->assertStringStartsWith("\033[31m", $logMessage);
+        $this->assertContains($message, $logMessage);
+        $this->assertStringEndsWith("\033[39m", $logMessage);
+    }
+
+    public function testLogCritical()
+    {
+        $resource = fopen('php://memory', 'a');
+        $logger = new CliColor('name', $resource);
+
+        $message = 'Test Log Message';
+        $logger->log(LogLevel::CRITICAL, $message);
+
+        rewind($resource);
+        $logMessage = fread($resource, 1024);
+        $this->assertStringStartsWith("\033[31;43m", $logMessage);
+        $this->assertContains($message, $logMessage);
+        $this->assertStringEndsWith("\033[39;49m", $logMessage);
+    }
+
+    public function testLogAlert()
+    {
+        $resource = fopen('php://memory', 'a');
+        $logger = new CliColor('name', $resource);
+
+        $message = 'Test Log Message';
+        $logger->log(LogLevel::ALERT, $message);
+
+        rewind($resource);
+        $logMessage = fread($resource, 1024);
+        $this->assertStringStartsWith("\033[37;41;1m", $logMessage);
+        $this->assertContains($message, $logMessage);
+        $this->assertStringEndsWith("\033[39;49;22m", $logMessage);
+    }
+
+    public function testLogEmergency()
+    {
+        $resource = fopen('php://memory', 'a');
+        $logger = new CliColor('name', $resource);
+
+        $message = 'Test Log Message';
+        $logger->log(LogLevel::EMERGENCY, $message);
+
+        rewind($resource);
+        $logMessage = fread($resource, 1024);
+        $this->assertStringStartsWith("\033[37;41;1;4m", $logMessage);
+        $this->assertContains($message, $logMessage);
+        $this->assertStringEndsWith("\033[39;49;22;24m", $logMessage);
+    }
+}

--- a/tests/CliColorTest.php
+++ b/tests/CliColorTest.php
@@ -47,7 +47,7 @@ class CliColorTest extends \PHPUnit_Framework_TestCase
         $logMessage = fread($resource, 1024);
         $this->assertStringStartsWith("\033[32m", $logMessage);
         $this->assertContains($message, $logMessage);
-        $this->assertStringEndsWith("\033[39m\n", $logMessage);
+        $this->assertStringEndsWith("\033[39m" . PHP_EOL, $logMessage);
     }
 
     public function testLogWarning()
@@ -62,7 +62,7 @@ class CliColorTest extends \PHPUnit_Framework_TestCase
         $logMessage = fread($resource, 1024);
         $this->assertStringStartsWith("\033[33m", $logMessage);
         $this->assertContains($message, $logMessage);
-        $this->assertStringEndsWith("\033[39m\n", $logMessage);
+        $this->assertStringEndsWith("\033[39m" . PHP_EOL, $logMessage);
     }
 
     public function testLogError()
@@ -77,7 +77,7 @@ class CliColorTest extends \PHPUnit_Framework_TestCase
         $logMessage = fread($resource, 1024);
         $this->assertStringStartsWith("\033[31m", $logMessage);
         $this->assertContains($message, $logMessage);
-        $this->assertStringEndsWith("\033[39m\n", $logMessage);
+        $this->assertStringEndsWith("\033[39m" . PHP_EOL, $logMessage);
     }
 
     public function testLogCritical()
@@ -92,7 +92,7 @@ class CliColorTest extends \PHPUnit_Framework_TestCase
         $logMessage = fread($resource, 1024);
         $this->assertStringStartsWith("\033[31;43m", $logMessage);
         $this->assertContains($message, $logMessage);
-        $this->assertStringEndsWith("\033[39;49m\n", $logMessage);
+        $this->assertStringEndsWith("\033[39;49m" . PHP_EOL, $logMessage);
     }
 
     public function testLogAlert()
@@ -107,7 +107,7 @@ class CliColorTest extends \PHPUnit_Framework_TestCase
         $logMessage = fread($resource, 1024);
         $this->assertStringStartsWith("\033[37;41;1m", $logMessage);
         $this->assertContains($message, $logMessage);
-        $this->assertStringEndsWith("\033[39;49;22m\n", $logMessage);
+        $this->assertStringEndsWith("\033[39;49;22m" . PHP_EOL, $logMessage);
     }
 
     public function testLogEmergency()
@@ -122,6 +122,6 @@ class CliColorTest extends \PHPUnit_Framework_TestCase
         $logMessage = fread($resource, 1024);
         $this->assertStringStartsWith("\033[37;41;1;4m", $logMessage);
         $this->assertContains($message, $logMessage);
-        $this->assertStringEndsWith("\033[39;49;22;24m\n", $logMessage);
+        $this->assertStringEndsWith("\033[39;49;22;24m" . PHP_EOL, $logMessage);
     }
 }

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -40,7 +40,7 @@ class StreamTest extends \PHPUnit_Framework_TestCase
         rewind($resource);
         $logMessage = fgets($resource);
 
-        $this->assertEquals($streamName, $logMessage);
+        $this->assertEquals($streamName . PHP_EOL, $logMessage);
     }
 
     public function testMessageFormatLevel()
@@ -54,7 +54,7 @@ class StreamTest extends \PHPUnit_Framework_TestCase
 
         rewind($resource);
         $logMessage = fgets($resource);
-        $this->assertEquals($level, $logMessage);
+        $this->assertEquals($level . PHP_EOL, $logMessage);
     }
 
     public function testMessageFormatMessage()
@@ -68,7 +68,7 @@ class StreamTest extends \PHPUnit_Framework_TestCase
 
         rewind($resource);
         $logMessage = fgets($resource);
-        $this->assertEquals($message, $logMessage);
+        $this->assertEquals($message . PHP_EOL, $logMessage);
     }
 
     public function testMessageFormatContext()
@@ -93,7 +93,7 @@ class StreamTest extends \PHPUnit_Framework_TestCase
         $context['exception'] = (string)$contextException;
         $contextString = json_encode($context, JSON_UNESCAPED_SLASHES);
 
-        $this->assertEquals($contextString, $logMessage);
+        $this->assertEquals($contextString . PHP_EOL, $logMessage);
     }
 
     public function testNewDateFormat()
@@ -109,7 +109,7 @@ class StreamTest extends \PHPUnit_Framework_TestCase
         rewind($resource);
         $logMessage = fgets($resource);
 
-        $this->assertStringMatchesFormat('%d/%d/%d', $logMessage);
+        $this->assertStringMatchesFormat('%d/%d/%d' . PHP_EOL, $logMessage);
     }
 
     public function testStringResource()
@@ -133,7 +133,7 @@ class StreamTest extends \PHPUnit_Framework_TestCase
         rewind($resource);
         $logMessage = fgets($resource);
 
-        $this->assertEquals('true', $logMessage);
+        $this->assertEquals('true' . PHP_EOL, $logMessage);
     }
 
     public function testFormatContextString()
@@ -150,7 +150,7 @@ class StreamTest extends \PHPUnit_Framework_TestCase
         rewind($resource);
         $logMessage = fgets($resource);
 
-        $this->assertEquals('value', $logMessage);
+        $this->assertEquals('value' . PHP_EOL, $logMessage);
     }
 
     public function testFormatContextNull()
@@ -167,7 +167,7 @@ class StreamTest extends \PHPUnit_Framework_TestCase
         rewind($resource);
         $logMessage = fgets($resource);
 
-        $this->assertEquals('NULL', $logMessage);
+        $this->assertEquals('NULL' . PHP_EOL, $logMessage);
     }
 
     public function testFormatContextClass()
@@ -186,7 +186,7 @@ class StreamTest extends \PHPUnit_Framework_TestCase
         rewind($resource);
         $logMessage = fgets($resource);
 
-        $this->assertEquals('stdClass', $logMessage);
+        $this->assertEquals('stdClass' . PHP_EOL, $logMessage);
     }
 
     public function testFormatContextRawType()
@@ -203,6 +203,6 @@ class StreamTest extends \PHPUnit_Framework_TestCase
         rewind($resource);
         $logMessage = fgets($resource);
 
-        $this->assertEquals('array', $logMessage);
+        $this->assertEquals('array' . PHP_EOL, $logMessage);
     }
 }


### PR DESCRIPTION
Extend Stream logger to add a CLI-specific logger which adds level-based colours.

Uses Symfony Console to deal with the colours. v2.5 branch is included to provide BC to php54, otherwise v3 is preferred. The two classes we're using do not functionally change between these versions.
