### PR TITLE
Add Decorators which can be registered on the Factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Custom logger decorators can be registered on the Factory and applied via config
+
+### Changed
+- Renamed `LevelFilter` to `Decorator\LevelFilter`
 
 ## [2.1.1] - 2016-10-27
 ### Added

--- a/src/Decorator/AbstractDecorator.php
+++ b/src/Decorator/AbstractDecorator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Phlib\Logger\Decorator;
+
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @package Phlib\Logger
+ */
+abstract class AbstractDecorator extends AbstractLogger
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var mixed
+     */
+    protected $config;
+
+    /**
+     * @param LoggerInterface $logger
+     * @param mixed $config
+     */
+    public function __construct(LoggerInterface $logger, $config)
+    {
+        $this->logger = $logger;
+        $this->config = $config;
+    }
+
+    /**
+     * @return LoggerInterface
+     */
+    protected function getInnerLogger()
+    {
+        return $this->logger;
+    }
+}

--- a/src/Decorator/AbstractDecorator.php
+++ b/src/Decorator/AbstractDecorator.php
@@ -16,18 +16,19 @@ abstract class AbstractDecorator extends AbstractLogger
     private $logger;
 
     /**
-     * @var mixed
-     */
-    protected $config;
-
-    /**
+     * AbstractDecorator constructor
+     *
+     * Stores the Logger for re-use in the concrete via getInnerLogger()
+     *
+     * If the concrete requires use of the config value, override the constructor
+     * to add validation and store for re-use
+     *
      * @param LoggerInterface $logger
      * @param mixed $config
      */
     public function __construct(LoggerInterface $logger, $config)
     {
         $this->logger = $logger;
-        $this->config = $config;
     }
 
     /**

--- a/src/Decorator/LevelFilter.php
+++ b/src/Decorator/LevelFilter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phlib\Logger;
+namespace Phlib\Logger\Decorator;
 
 use Psr\Log\LogLevel;
 use Psr\Log\AbstractLogger;

--- a/src/Decorator/LevelFilter.php
+++ b/src/Decorator/LevelFilter.php
@@ -3,7 +3,6 @@
 namespace Phlib\Logger\Decorator;
 
 use Psr\Log\LogLevel;
-use Psr\Log\AbstractLogger;
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 
@@ -11,7 +10,7 @@ use Psr\Log\LoggerInterface;
  * Class LevelFilter
  * @package Phlib\Logger
  */
-class LevelFilter extends AbstractLogger
+class LevelFilter extends AbstractDecorator
 {
     /**
      * Logging levels from syslog protocol defined in RFC 5424
@@ -30,32 +29,22 @@ class LevelFilter extends AbstractLogger
     );
 
     /**
-     * @var int
-     */
-    private $logLevel;
-
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
      * @param LoggerInterface $logger
-     * @param $level
+     * @param int $config
      */
-    public function __construct(LoggerInterface $logger, $level)
+    public function __construct(LoggerInterface $logger, $config)
     {
-        $this->logger = $logger;
-
-        $this->logLevel = array_search($level, self::$levels, true);
-        if ($this->logLevel === false) {
+        $config = array_search($config, self::$levels, true);
+        if ($config === false) {
             throw new InvalidArgumentException(
                 sprintf(
                     'Cannot use logging level "%s"',
-                    $level
+                    $config
                 )
             );
         }
+
+        parent::__construct($logger, $config);
     }
 
     /**
@@ -77,10 +66,10 @@ class LevelFilter extends AbstractLogger
                 )
             );
         }
-        if ($levelCode > $this->logLevel) {
+        if ($levelCode > $this->config) {
             return;
         }
 
-        $this->logger->log($level, $message, $context);
+        $this->getInnerLogger()->log($level, $message, $context);
     }
 }

--- a/src/Decorator/LevelFilter.php
+++ b/src/Decorator/LevelFilter.php
@@ -29,22 +29,27 @@ class LevelFilter extends AbstractDecorator
     );
 
     /**
-     * @param LoggerInterface $logger
-     * @param int $config
+     * @var int
      */
-    public function __construct(LoggerInterface $logger, $config)
+    private $logLevel;
+
+    /**
+     * @param LoggerInterface $logger
+     * @param string $level \Psr\Log\LogLevel string
+     */
+    public function __construct(LoggerInterface $logger, $level)
     {
-        $config = array_search($config, self::$levels, true);
-        if ($config === false) {
+        parent::__construct($logger, $level);
+
+        $this->logLevel = array_search($level, self::$levels, true);
+        if ($this->logLevel === false) {
             throw new InvalidArgumentException(
                 sprintf(
                     'Cannot use logging level "%s"',
-                    $config
+                    $level
                 )
             );
         }
-
-        parent::__construct($logger, $config);
     }
 
     /**
@@ -66,7 +71,7 @@ class LevelFilter extends AbstractDecorator
                 )
             );
         }
-        if ($levelCode > $this->config) {
+        if ($levelCode > $this->logLevel) {
             return;
         }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -33,7 +33,7 @@ class Factory
         $logger   = $this->$methodName($name, $config);
         $logLevel = isset($config['level']) ? $config['level'] : LogLevel::DEBUG;
         if ($logLevel !== LogLevel::DEBUG) {
-            return new LevelFilter($logger, $logLevel);
+            return new Decorator\LevelFilter($logger, $logLevel);
         }
         return $logger;
     }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -3,7 +3,6 @@
 namespace Phlib\Logger;
 
 use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 
 /**
  * Class Factory
@@ -11,6 +10,9 @@ use Psr\Log\LogLevel;
  */
 class Factory
 {
+    /**
+     * @var array
+     */
     private $decorators = [
         'level' => '\Phlib\Logger\Decorator\LevelFilter'
     ];

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -68,6 +68,21 @@ class Factory
         }
         $logger = $this->$methodName($name, $config);
 
+        $logger = $this->applyDecorators($logger, $config);
+
+        return $logger;
+    }
+
+    /**
+     * Apply any available decorators to the logger, if configured
+     *
+     * @param LoggerInterface $logger
+     * @param array $config
+     *
+     * @return LoggerInterface
+     */
+    private function applyDecorators(LoggerInterface $logger, array $config)
+    {
         foreach ($this->decorators as $configKey => $decoratorClassName) {
             if (!isset($config[$configKey])) {
                 continue;

--- a/tests/Decorator/LevelFilterTest.php
+++ b/tests/Decorator/LevelFilterTest.php
@@ -1,7 +1,8 @@
 <?php
-namespace Phlib\Logger\Test;
 
-use Phlib\Logger\LevelFilter;
+namespace Phlib\Logger\Test\Decorator;
+
+use Phlib\Logger\Decorator\LevelFilter;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -126,7 +126,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             'path'  => $fh
         ]);
 
-        $this->assertInstanceOf('\Phlib\Logger\LevelFilter', $logger);
+        $this->assertInstanceOf('\Phlib\Logger\Decorator\LevelFilter', $logger);
     }
 
     /**


### PR DESCRIPTION
Moving Decorators to a namespace with an Abstract allows implementations to configure them dynamically.
