### PR TITLE
Add change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/) 
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Added
+- Mark package as providing an implementation of `\Psr\Log` by using Composer `provide` option
+
+## [2.1.0] - 2016-04-29
+### Added
+- CliColor logger which can be manually constructed to add coloured log output to your CLI scripts' verbose mode.
+- Officially support php70
+
+## [2.0.1] - 2016-03-21
+### Added
+- Support for additional handlers by extending Factory
+
+## [2.0.0] - 2016-03-21
+### Added
+- New Config class to separate the logic for interpreting the pool's config. Changes the Pool's constructor.
+
+### Changed
+- Config key `name` renamed to `type`
+
+## [1.1.0] - 2015-08-26
+### Added
+- New Pool method to allow user to always get a collection logger
+
+## [1.0.1] - 2015-08-25
+### Added
+- README.md
+
+### Changed
+- Composer lock file is no longer committed, to avoid [dependency hell](https://philsturgeon.uk/php/2014/11/04/composer-its-almost-always-about-the-lock-file/)
+
+## [1.0.0] - 2015-08-25
+Initial Release


### PR DESCRIPTION
The fact that we already have something in `[Unreleased]` suggests we should tag a new release before merging #9 
