### PR TITLE
Add support for psr/log v2 and v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add support for `psr/log` v2 and v3.
+- Add support for passing `Stringable` objects as the `$message` parameter to
+  `log()` methods. 
 
 ## [4.0.0] - 2021-05-31
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.3|^8",
         "ext-json": "*",
-        "psr/log": "^1.0",
+        "psr/log": "^1 || ^2 || ^3",
         "graylog2/gelf-php": "^1.3",
         "symfony/console": "^2.5.12|^3|^4|^5"
     },
@@ -27,7 +27,7 @@
         }
     },
     "provide": {
-        "psr/log-implementation": "1.0"
+        "psr/log-implementation": "1.0 || 2.0 || 3.0"
     },
 
     "require-dev": {

--- a/src/Decorator/DefaultContext.php
+++ b/src/Decorator/DefaultContext.php
@@ -28,13 +28,8 @@ class DefaultContext extends AbstractDecorator
     }
 
     /**
-     * Logs with an arbitrary level.
-     *
-     * @param mixed  $level
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed $level
+     * @param string|\Stringable $message
      */
     public function log($level, $message, array $context = []): void
     {

--- a/src/Decorator/LevelFilter.php
+++ b/src/Decorator/LevelFilter.php
@@ -51,13 +51,8 @@ class LevelFilter extends AbstractDecorator
     }
 
     /**
-     * Logs with an arbitrary level.
-     *
-     * @param mixed  $level
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed $level
+     * @param string|\Stringable $message
      */
     public function log($level, $message, array $context = []): void
     {

--- a/src/LoggerType/Collection.php
+++ b/src/LoggerType/Collection.php
@@ -39,16 +39,12 @@ class Collection extends AbstractLogger
     }
 
     /**
-     * Logs with an arbitrary level.
-     *
-     * @param mixed  $level
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed $level
+     * @param string|\Stringable $message
      */
     public function log($level, $message, array $context = []): void
     {
+        /** @var LoggerInterface $logger */
         foreach ($this->loggerInstances as $logger) {
             $logger->log($level, $message, $context);
         }

--- a/src/LoggerType/Stream.php
+++ b/src/LoggerType/Stream.php
@@ -78,13 +78,8 @@ class Stream extends AbstractLogger
     }
 
     /**
-     * Logs with an arbitrary level.
-     *
-     * @param mixed  $level
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed $level
+     * @param string|\Stringable $message
      */
     public function log($level, $message, array $context = []): void
     {
@@ -92,7 +87,7 @@ class Stream extends AbstractLogger
             'datetime' => date($this->dateFormat),
             'name'     => $this->name,
             'level'    => $level,
-            'message'  => $this->formatMessage($message, $context),
+            'message'  => $this->formatMessage((string)$message, $context),
             'context'  => $this->formatContext($context)
         ];
 


### PR DESCRIPTION
* Both require PHP v8, so support for v1 is still required by this package's PHP v7 support.
* psr/log v2 adds `\Stringable` to the type declaration for `$message`, so handling needs to cast to string.
* psr/log v3 adds void return types that this package already implements, so no BC break is needed.